### PR TITLE
Update mpt and poseidon circuit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3230,7 +3230,7 @@ dependencies = [
 [[package]]
 name = "poseidon-circuit"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/poseidon-circuit.git?branch=scroll-dev-0201#ceda6061aa5e5d09ca5dfd5d90c581eb54077fc0"
+source = "git+https://github.com/scroll-tech/poseidon-circuit.git?branch=scroll-dev-0201#614d979360bdbf2fac6d32dd4733cf4810dd0d47"
 dependencies = [
  "bitvec 1.0.1",
  "halo2_proofs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,6 @@ checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 [[package]]
 name = "bus-mapping"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-stable#c85ace5731cdb4032ceefcf3dab63ae4f9a30d14"
 dependencies = [
  "eth-types",
  "ethers-core",
@@ -993,6 +992,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
 
 [[package]]
+name = "ecc"
+version = "0.1.0"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_02_02#5905a20b62fcd9f6c269416a39c80de7ced8fb02"
+dependencies = [
+ "group",
+ "integer",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "rand 0.8.5",
+ "subtle",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,7 +1152,6 @@ dependencies = [
 [[package]]
 name = "eth-types"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-stable#c85ace5731cdb4032ceefcf3dab63ae4f9a30d14"
 dependencies = [
  "ethers-core",
  "ethers-signers",
@@ -1401,7 +1413,6 @@ dependencies = [
 [[package]]
 name = "external-tracer"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-stable#c85ace5731cdb4032ceefcf3dab63ae4f9a30d14"
 dependencies = [
  "eth-types",
  "geth-utils",
@@ -1714,7 +1725,6 @@ dependencies = [
 [[package]]
 name = "gadgets"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-stable#c85ace5731cdb4032ceefcf3dab63ae4f9a30d14"
 dependencies = [
  "digest 0.7.6",
  "eth-types",
@@ -1754,7 +1764,6 @@ dependencies = [
 [[package]]
 name = "geth-utils"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-stable#c85ace5731cdb4032ceefcf3dab63ae4f9a30d14"
 dependencies = [
  "env_logger",
  "gobuild",
@@ -2361,6 +2370,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer"
+version = "0.1.0"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_02_02#5905a20b62fcd9f6c269416a39c80de7ced8fb02"
+dependencies = [
+ "group",
+ "maingate",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "rand 0.8.5",
+ "subtle",
+]
+
+[[package]]
 name = "integer-sqrt"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2452,7 +2475,6 @@ checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 [[package]]
 name = "keccak256"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-stable#c85ace5731cdb4032ceefcf3dab63ae4f9a30d14"
 dependencies = [
  "env_logger",
  "eth-types",
@@ -2693,7 +2715,6 @@ dependencies = [
 [[package]]
 name = "mock"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-stable#c85ace5731cdb4032ceefcf3dab63ae4f9a30d14"
 dependencies = [
  "eth-types",
  "ethers-core",
@@ -2708,7 +2729,6 @@ dependencies = [
 [[package]]
 name = "mpt-zktrie"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-stable#c85ace5731cdb4032ceefcf3dab63ae4f9a30d14"
 dependencies = [
  "bus-mapping",
  "eth-types",
@@ -3230,7 +3250,6 @@ dependencies = [
 [[package]]
 name = "poseidon-circuit"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/poseidon-circuit.git?branch=scroll-dev-0201#614d979360bdbf2fac6d32dd4733cf4810dd0d47"
 dependencies = [
  "bitvec 1.0.1",
  "halo2_proofs",
@@ -4097,6 +4116,24 @@ name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+
+[[package]]
+name = "snark-verifier"
+version = "0.1.0"
+source = "git+https://github.com/privacy-scaling-explorations/snark-verifier?tag=v2023_02_02#df03d898b841f71cbc36c2fb9fa07b8196f9623e"
+dependencies = [
+ "ecc",
+ "halo2_proofs",
+ "halo2curves 0.3.1 (git+https://github.com/privacy-scaling-explorations/halo2curves.git?tag=0.3.1)",
+ "hex",
+ "itertools",
+ "lazy_static",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "poseidon",
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "socket2"
@@ -5727,7 +5764,6 @@ dependencies = [
 [[package]]
 name = "zkevm-circuits"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-stable#c85ace5731cdb4032ceefcf3dab63ae4f9a30d14"
 dependencies = [
  "array-init",
  "bus-mapping",
@@ -5757,6 +5793,7 @@ dependencies = [
  "rayon",
  "rlp",
  "sha3 0.10.1",
+ "snark-verifier",
  "strum",
  "strum_macros",
  "subtle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,26 +296,14 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
-dependencies = [
- "funty 1.2.0",
- "radium 0.6.2",
- "tap",
- "wyz 0.4.0",
-]
-
-[[package]]
-name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
- "funty 2.0.0",
+ "funty",
  "radium 0.7.0",
  "tap",
- "wyz 0.5.0",
+ "wyz",
 ]
 
 [[package]]
@@ -1611,12 +1599,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "funty"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
 name = "funty"
@@ -3269,7 +3251,7 @@ name = "poseidon-circuit"
 version = "0.1.0"
 source = "git+https://github.com/scroll-tech/poseidon-circuit.git?branch=scroll-dev-0111-halo2-upgrade#b6761f8fc778c9851d874aa21fb3c4271071b717"
 dependencies = [
- "bitvec 0.22.3",
+ "bitvec 1.0.1",
  "halo2_proofs",
  "lazy_static",
  "thiserror",
@@ -3406,12 +3388,6 @@ name = "radium"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
-
-[[package]]
-name = "radium"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "radium"
@@ -5711,15 +5687,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wyz"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
-dependencies = [
- "tap",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,7 @@ checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 [[package]]
 name = "bus-mapping"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-stable#1308f42190fa95d6c23b78991175f7783818e6fe"
 dependencies = [
  "eth-types",
  "ethers-core",
@@ -1152,6 +1153,7 @@ dependencies = [
 [[package]]
 name = "eth-types"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-stable#1308f42190fa95d6c23b78991175f7783818e6fe"
 dependencies = [
  "ethers-core",
  "ethers-signers",
@@ -1413,6 +1415,7 @@ dependencies = [
 [[package]]
 name = "external-tracer"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-stable#1308f42190fa95d6c23b78991175f7783818e6fe"
 dependencies = [
  "eth-types",
  "geth-utils",
@@ -1725,6 +1728,7 @@ dependencies = [
 [[package]]
 name = "gadgets"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-stable#1308f42190fa95d6c23b78991175f7783818e6fe"
 dependencies = [
  "digest 0.7.6",
  "eth-types",
@@ -1764,6 +1768,7 @@ dependencies = [
 [[package]]
 name = "geth-utils"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-stable#1308f42190fa95d6c23b78991175f7783818e6fe"
 dependencies = [
  "env_logger",
  "gobuild",
@@ -1865,6 +1870,8 @@ dependencies = [
 [[package]]
 name = "gobuild"
 version = "0.1.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e156a4ddbf3deb5e8116946c111413bd9a5679bdc1536c78a60618a7a9ac9e"
 dependencies = [
  "cc",
 ]
@@ -2475,6 +2482,7 @@ checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 [[package]]
 name = "keccak256"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-stable#1308f42190fa95d6c23b78991175f7783818e6fe"
 dependencies = [
  "env_logger",
  "eth-types",
@@ -2715,6 +2723,7 @@ dependencies = [
 [[package]]
 name = "mock"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-stable#1308f42190fa95d6c23b78991175f7783818e6fe"
 dependencies = [
  "eth-types",
  "ethers-core",
@@ -2729,6 +2738,7 @@ dependencies = [
 [[package]]
 name = "mpt-zktrie"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-stable#1308f42190fa95d6c23b78991175f7783818e6fe"
 dependencies = [
  "bus-mapping",
  "eth-types",
@@ -3250,6 +3260,7 @@ dependencies = [
 [[package]]
 name = "poseidon-circuit"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/poseidon-circuit.git?branch=scroll-dev-0201#614d979360bdbf2fac6d32dd4733cf4810dd0d47"
 dependencies = [
  "bitvec 1.0.1",
  "halo2_proofs",
@@ -5571,6 +5582,8 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "windows-sys"
 version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
  "windows_aarch64_msvc 0.36.1",
  "windows_i686_gnu 0.36.1",
@@ -5764,6 +5777,7 @@ dependencies = [
 [[package]]
 name = "zkevm-circuits"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-stable#1308f42190fa95d6c23b78991175f7783818e6fe"
 dependencies = [
  "array-init",
  "bus-mapping",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,7 +1143,7 @@ source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-st
 dependencies = [
  "ethers-core",
  "ethers-signers",
- "halo2-mpt-circuits 0.1.0 (git+https://github.com/scroll-tech/mpt-circuit.git?branch=scroll-dev-0129)",
+ "halo2-mpt-circuits",
  "halo2_proofs",
  "hex",
  "itertools",
@@ -1856,8 +1856,6 @@ dependencies = [
 [[package]]
 name = "gobuild"
 version = "0.1.0-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e156a4ddbf3deb5e8116946c111413bd9a5679bdc1536c78a60618a7a9ac9e"
 dependencies = [
  "cc",
 ]
@@ -1908,30 +1906,13 @@ dependencies = [
 [[package]]
 name = "halo2-mpt-circuits"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/mpt-circuit.git?branch=scroll-dev-0111-halo2-upgrade#1aa8aa43289d9f29c2c8dbd5b2384f56bfd90fff"
-dependencies = [
- "halo2_proofs",
- "hex",
- "lazy_static",
- "log",
- "num-bigint",
- "poseidon-circuit 0.1.0 (git+https://github.com/scroll-tech/poseidon-circuit.git?branch=scroll-dev-0111-halo2-upgrade)",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "halo2-mpt-circuits"
-version = "0.1.0"
 source = "git+https://github.com/scroll-tech/mpt-circuit.git?branch=scroll-dev-0129#631d71fd4dbe070fee34416efbfd12241d78c62f"
 dependencies = [
  "halo2_proofs",
  "hex",
  "lazy_static",
  "num-bigint",
- "poseidon-circuit 0.1.0 (git+https://github.com/scroll-tech/poseidon-circuit.git?branch=scroll-dev-0201)",
+ "poseidon-circuit",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -2731,7 +2712,7 @@ source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=scroll-st
 dependencies = [
  "bus-mapping",
  "eth-types",
- "halo2-mpt-circuits 0.1.0 (git+https://github.com/scroll-tech/mpt-circuit.git?branch=scroll-dev-0129)",
+ "halo2-mpt-circuits",
  "halo2_proofs",
  "lazy_static",
  "log",
@@ -3249,18 +3230,7 @@ dependencies = [
 [[package]]
 name = "poseidon-circuit"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/poseidon-circuit.git?branch=scroll-dev-0111-halo2-upgrade#b6761f8fc778c9851d874aa21fb3c4271071b717"
-dependencies = [
- "bitvec 1.0.1",
- "halo2_proofs",
- "lazy_static",
- "thiserror",
-]
-
-[[package]]
-name = "poseidon-circuit"
-version = "0.1.0"
-source = "git+https://github.com/scroll-tech/poseidon-circuit.git?branch=scroll-dev-0201#614d979360bdbf2fac6d32dd4733cf4810dd0d47"
+source = "git+https://github.com/scroll-tech/poseidon-circuit.git?branch=scroll-dev-0201#ceda6061aa5e5d09ca5dfd5d90c581eb54077fc0"
 dependencies = [
  "bitvec 1.0.1",
  "halo2_proofs",
@@ -5051,7 +5021,6 @@ dependencies = [
  "blake2",
  "eth-types",
  "ethers-core",
- "halo2-mpt-circuits 0.1.0 (git+https://github.com/scroll-tech/mpt-circuit.git?branch=scroll-dev-0111-halo2-upgrade)",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5565,8 +5534,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "windows-sys"
 version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
  "windows_aarch64_msvc 0.36.1",
  "windows_i686_gnu 0.36.1",
@@ -5733,7 +5700,6 @@ dependencies = [
  "ethers-core",
  "git-version",
  "glob",
- "halo2-mpt-circuits 0.1.0 (git+https://github.com/scroll-tech/mpt-circuit.git?branch=scroll-dev-0111-halo2-upgrade)",
  "halo2-snark-aggregator-api",
  "halo2-snark-aggregator-circuit",
  "halo2-snark-aggregator-solidity",

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-eth-types = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "scroll-stable" }
-mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/scroll-tech/mpt-circuit.git", branch = "scroll-dev-0111-halo2-upgrade" }
+eth-types = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "feat/poseidon-circuit" }
+#mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/scroll-tech/mpt-circuit.git", branch = "scroll-dev-0129" }
 base64 = "0.13.0"
 blake2 = "0.10.3"
 ethers-core = "0.17.0"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-eth-types = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "feat/poseidon-circuit" }
+eth-types = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "scroll-stable" }
 #mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/scroll-tech/mpt-circuit.git", branch = "scroll-dev-0129" }
 base64 = "0.13.0"
 blake2 = "0.10.3"

--- a/types/src/eth.rs
+++ b/types/src/eth.rs
@@ -1,7 +1,7 @@
 use eth_types::evm_types::{Gas, GasCost, OpcodeId, ProgramCounter, Stack, Storage};
 use eth_types::{Block, GethExecStep, GethExecTrace, Hash, Transaction, Word, H256};
 use ethers_core::types::{Address, Bytes, U256, U64};
-use mpt_circuits::serde::SMTTrace;
+//use mpt_circuits::serde::SMTTrace;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -14,8 +14,8 @@ pub struct BlockTrace {
     pub execution_results: Vec<ExecutionResult>,
     #[serde(rename = "storageTrace")]
     pub storage_trace: StorageTrace,
-    #[serde(rename = "mptwitness", default)]
-    pub mpt_witness: Vec<SMTTrace>,
+//    #[serde(rename = "mptwitness", default)]
+//    pub mpt_witness: Vec<SMTTrace>,
 }
 
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]

--- a/types/src/eth.rs
+++ b/types/src/eth.rs
@@ -14,8 +14,8 @@ pub struct BlockTrace {
     pub execution_results: Vec<ExecutionResult>,
     #[serde(rename = "storageTrace")]
     pub storage_trace: StorageTrace,
-//    #[serde(rename = "mptwitness", default)]
-//    pub mpt_witness: Vec<SMTTrace>,
+    //    #[serde(rename = "mptwitness", default)]
+    //    pub mpt_witness: Vec<SMTTrace>,
 }
 
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]

--- a/zkevm/Cargo.toml
+++ b/zkevm/Cargo.toml
@@ -13,12 +13,12 @@ halo2-snark-aggregator-api = { git = "https://github.com/scroll-tech/halo2-snark
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10" }
 #halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10", features = ["phase-check"] }
 
-bus-mapping = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "scroll-stable" }
-eth-types = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "scroll-stable" }
-zkevm-circuits = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "scroll-stable", default-features = false, features = ["test", "zktrie","poseidon-codehash","enable-sign-verify"] }
-mpt-zktrie = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "scroll-stable" }
+bus-mapping = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "feat/poseidon-circuit" }
+eth-types = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "feat/poseidon-circuit" }
+zkevm-circuits = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "feat/poseidon-circuit", default-features = false, features = ["test","zktrie","poseidon-codehash","enable-sign-verify"] }
+mpt-zktrie = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "feat/poseidon-circuit" }
 
-mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/scroll-tech/mpt-circuit.git", branch = "scroll-dev-0111-halo2-upgrade" }
+#mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/scroll-tech/mpt-circuit.git", branch = "scroll-dev-0129" }
 
 rand = "0.8"
 rand_xorshift = "0.3"

--- a/zkevm/Cargo.toml
+++ b/zkevm/Cargo.toml
@@ -13,10 +13,10 @@ halo2-snark-aggregator-api = { git = "https://github.com/scroll-tech/halo2-snark
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10" }
 #halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10", features = ["phase-check"] }
 
-bus-mapping = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "feat/poseidon-circuit" }
-eth-types = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "feat/poseidon-circuit" }
-zkevm-circuits = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "feat/poseidon-circuit", default-features = false, features = ["test","zktrie","poseidon-codehash","enable-sign-verify"] }
-mpt-zktrie = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "feat/poseidon-circuit" }
+bus-mapping = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "scroll-stable" }
+eth-types = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "scroll-stable" }
+zkevm-circuits = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "scroll-stable", default-features = false, features = ["test","zktrie","poseidon-codehash","enable-sign-verify"] }
+mpt-zktrie = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "scroll-stable" }
 
 #mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/scroll-tech/mpt-circuit.git", branch = "scroll-dev-0129" }
 

--- a/zkevm/src/circuit.rs
+++ b/zkevm/src/circuit.rs
@@ -7,12 +7,12 @@ use once_cell::sync::Lazy;
 
 use types::eth::BlockTrace;
 
-use zkevm_circuits::util::SubCircuit;
 use zkevm_circuits::evm_circuit::EvmCircuit as EvmCircuitImpl;
-use zkevm_circuits::state_circuit::StateCircuit as StateCircuitImpl;
-use zkevm_circuits::super_circuit::SuperCircuit as SuperCircuitImpl;
 use zkevm_circuits::mpt_circuit::MptCircuit as ZktrieCircuitImpl;
 use zkevm_circuits::poseidon_circuit::PoseidonCircuit as PoseidonCircuitImpl;
+use zkevm_circuits::state_circuit::StateCircuit as StateCircuitImpl;
+use zkevm_circuits::super_circuit::SuperCircuit as SuperCircuitImpl;
+use zkevm_circuits::util::SubCircuit;
 use zkevm_circuits::witness;
 
 mod builder;
@@ -196,7 +196,7 @@ impl TargetCircuit for StateCircuit {
     }
 }
 
-/* 
+/*
 fn trie_data_from_blocks<'d>(
     block_traces: impl IntoIterator<Item = &'d BlockTrace>,
 ) -> EthTrie<Fr> {
@@ -235,11 +235,10 @@ impl TargetCircuit for ZktrieCircuit {
     fn from_witness_block(
         witness_block: &witness::Block<Fr>,
     ) -> anyhow::Result<(Self::Inner, Vec<Vec<Fr>>)>
-    where Self: Sized,
+    where
+        Self: Sized,
     {
-        let inner = ZktrieCircuitImpl::new_from_block(
-            &witness_block,
-        );
+        let inner = ZktrieCircuitImpl::new_from_block(witness_block);
         let instance = vec![];
         Ok((inner, instance))
     }
@@ -248,7 +247,6 @@ impl TargetCircuit for ZktrieCircuit {
         let witness_block = block_traces_to_witness_block(block_traces).unwrap();
         ZktrieCircuitImpl::min_num_rows_block(&witness_block).0
     }
-
 }
 
 pub struct PoseidonCircuit {}
@@ -263,11 +261,10 @@ impl TargetCircuit for PoseidonCircuit {
     fn from_witness_block(
         witness_block: &witness::Block<Fr>,
     ) -> anyhow::Result<(Self::Inner, Vec<Vec<Fr>>)>
-    where Self: Sized,
+    where
+        Self: Sized,
     {
-        let inner = PoseidonCircuitImpl::new_from_block(
-            &witness_block,
-        );
+        let inner = PoseidonCircuitImpl::new_from_block(witness_block);
         let instance = vec![];
         Ok((inner, instance))
     }
@@ -276,5 +273,4 @@ impl TargetCircuit for PoseidonCircuit {
         let witness_block = block_traces_to_witness_block(block_traces).unwrap();
         PoseidonCircuitImpl::min_num_rows_block(&witness_block).0
     }
-
 }

--- a/zkevm/src/circuit.rs
+++ b/zkevm/src/circuit.rs
@@ -3,16 +3,16 @@ use anyhow::bail;
 use halo2_proofs::halo2curves::bn256::Fr;
 use halo2_proofs::plonk::Circuit as Halo2Circuit;
 
-use mpt_circuits::{hash::Hashable, operation::AccountOp, EthTrie, EthTrieCircuit, HashCircuit};
-
 use once_cell::sync::Lazy;
 
 use types::eth::BlockTrace;
 
+use zkevm_circuits::util::SubCircuit;
 use zkevm_circuits::evm_circuit::EvmCircuit as EvmCircuitImpl;
 use zkevm_circuits::state_circuit::StateCircuit as StateCircuitImpl;
 use zkevm_circuits::super_circuit::SuperCircuit as SuperCircuitImpl;
-use zkevm_circuits::util::SubCircuit;
+use zkevm_circuits::mpt_circuit::MptCircuit as ZktrieCircuitImpl;
+use zkevm_circuits::poseidon_circuit::PoseidonCircuit as PoseidonCircuitImpl;
 use zkevm_circuits::witness;
 
 mod builder;
@@ -196,10 +196,7 @@ impl TargetCircuit for StateCircuit {
     }
 }
 
-fn mpt_rows() -> usize {
-    ((1 << *DEGREE) - 10) / <Fr as Hashable>::hash_block_size()
-}
-
+/* 
 fn trie_data_from_blocks<'d>(
     block_traces: impl IntoIterator<Item = &'d BlockTrace>,
 ) -> EthTrie<Fr> {
@@ -224,112 +221,60 @@ fn trie_data_from_blocks<'d>(
 
     trie_data
 }
+*/
 
 pub struct ZktrieCircuit {}
 
 impl TargetCircuit for ZktrieCircuit {
-    type Inner = EthTrieCircuit<Fr, true>;
+    type Inner = ZktrieCircuitImpl<Fr>;
 
     fn name() -> String {
         "zktrie".to_string()
     }
-    fn empty() -> Self::Inner {
-        let dummy_trie: EthTrie<Fr> = Default::default();
-        let (circuit, _) = dummy_trie.circuits(mpt_rows());
-        circuit
-    }
 
-    fn from_block_traces(block_traces: &[BlockTrace]) -> anyhow::Result<(Self::Inner, Vec<Vec<Fr>>)>
-    where
-        Self: Sized,
+    fn from_witness_block(
+        witness_block: &witness::Block<Fr>,
+    ) -> anyhow::Result<(Self::Inner, Vec<Vec<Fr>>)>
+    where Self: Sized,
     {
-        let trie_data = trie_data_from_blocks(block_traces);
-        let (rows, _) = trie_data.use_rows();
-        if rows >= mpt_rows() {
-            bail!("mpt row num overflow: {}", rows);
-        }
-        let (mpt_circuit, _) = trie_data.circuits(mpt_rows());
+        let inner = ZktrieCircuitImpl::new_from_block(
+            &witness_block,
+        );
         let instance = vec![];
-        Ok((mpt_circuit, instance))
-    }
-
-    fn from_block_trace(block_trace: &BlockTrace) -> anyhow::Result<(Self::Inner, Vec<Vec<Fr>>)>
-    where
-        Self: Sized,
-    {
-        let (mpt_circuit, _) = trie_data_from_blocks(Some(block_trace)).circuits(mpt_rows());
-        let instance = vec![];
-        Ok((mpt_circuit, instance))
+        Ok((inner, instance))
     }
 
     fn estimate_rows(block_traces: &[BlockTrace]) -> usize {
-        let (mpt_rows, _) = trie_data_from_blocks(block_traces).use_rows();
-        mpt_rows
+        let witness_block = block_traces_to_witness_block(block_traces).unwrap();
+        ZktrieCircuitImpl::min_num_rows_block(&witness_block).0
     }
 
-    fn get_active_rows(block_traces: &[BlockTrace]) -> (Vec<usize>, Vec<usize>) {
-        // we have compare and pick the maxium for lookup and gate rows, here we
-        // just make sure it not less than 64 (so it has contained all constant rows)
-        let ret = Self::estimate_rows(block_traces);
-        ((0..ret.max(64)).collect(), (0..ret.max(64)).collect())
-    }
-
-    fn from_witness_block(
-        _witness_block: &witness::Block<Fr>,
-    ) -> anyhow::Result<(Self::Inner, Vec<Vec<Fr>>)>
-    where
-        Self: Sized,
-    {
-        todo!()
-    }
 }
 
 pub struct PoseidonCircuit {}
 
 impl TargetCircuit for PoseidonCircuit {
-    type Inner = HashCircuit<Fr>;
+    type Inner = PoseidonCircuitImpl<Fr>;
 
     fn name() -> String {
         "poseidon".to_string()
     }
-    fn empty() -> Self::Inner {
-        let dummy_trie: EthTrie<Fr> = Default::default();
-        let (_, circuit) = dummy_trie.circuits(mpt_rows());
-        circuit
-    }
 
-    fn from_block_traces(block_traces: &[BlockTrace]) -> anyhow::Result<(Self::Inner, Vec<Vec<Fr>>)>
-    where
-        Self: Sized,
+    fn from_witness_block(
+        witness_block: &witness::Block<Fr>,
+    ) -> anyhow::Result<(Self::Inner, Vec<Vec<Fr>>)>
+    where Self: Sized,
     {
-        let trie_data = trie_data_from_blocks(block_traces);
-        //        let (_, rows) = trie_data.use_rows();
-        //        log::info!("poseidon use rows {}", rows);
-        let (_, circuit) = trie_data.circuits(mpt_rows());
+        let inner = PoseidonCircuitImpl::new_from_block(
+            &witness_block,
+        );
         let instance = vec![];
-        Ok((circuit, instance))
-    }
-
-    fn from_block_trace(block_trace: &BlockTrace) -> anyhow::Result<(Self::Inner, Vec<Vec<Fr>>)>
-    where
-        Self: Sized,
-    {
-        let (_, circuit) = trie_data_from_blocks(Some(block_trace)).circuits(mpt_rows());
-        let instance = vec![];
-        Ok((circuit, instance))
+        Ok((inner, instance))
     }
 
     fn estimate_rows(block_traces: &[BlockTrace]) -> usize {
-        let (_, rows) = trie_data_from_blocks(block_traces).use_rows();
-        rows
+        let witness_block = block_traces_to_witness_block(block_traces).unwrap();
+        PoseidonCircuitImpl::min_num_rows_block(&witness_block).0
     }
 
-    fn from_witness_block(
-        _witness_block: &witness::Block<Fr>,
-    ) -> anyhow::Result<(Self::Inner, Vec<Vec<Fr>>)>
-    where
-        Self: Sized,
-    {
-        todo!()
-    }
 }

--- a/zkevm/src/circuit/builder.rs
+++ b/zkevm/src/circuit/builder.rs
@@ -1,17 +1,19 @@
 use super::{mpt, MAX_CALLDATA, MAX_RWS, MAX_TXS};
 use crate::circuit::{TargetCircuit, AUTO_TRUNCATE, DEGREE, MAX_INNER_BLOCKS, MAX_KECCAK_ROWS};
 use bus_mapping::circuit_input_builder::{self, BlockHead, CircuitInputBuilder, CircuitsParams};
-use bus_mapping::state_db::{Account, CodeDB, StateDB};
+use bus_mapping::state_db::{Account, CodeDB, CodeHash, StateDB};
 use eth_types::evm_types::OpcodeId;
-use eth_types::ToAddress;
+use eth_types::{Hash, ToAddress};
 use ethers_core::types::{Address, Bytes, U256};
 use types::eth::{BlockTrace, EthBlock, ExecStep};
 
-use mpt_circuits::hash::Hashable;
+use mpt_zktrie::hash::Hashable;
 use mpt_zktrie::state::ZktrieState;
 use zkevm_circuits::evm_circuit::witness::block_apply_mpt_state;
 use zkevm_circuits::evm_circuit::witness::{block_convert, Block};
 use zkevm_circuits::util::SubCircuit;
+
+use zkevm_circuits::bytecode_circuit::bytecode_unroller::HASHBLOCK_BYTES_IN_FIELD;
 
 use halo2_proofs::arithmetic::FieldExt;
 use halo2_proofs::halo2curves::bn256::Fr;
@@ -58,7 +60,7 @@ const SUB_CIRCUIT_NAMES: [&str; 10] = [
 // TODO: optimize it later
 pub fn calculate_row_usage_of_trace(block_trace: &BlockTrace) -> Result<Vec<usize>, anyhow::Error> {
     let witness_block = block_traces_to_witness_block(std::slice::from_ref(block_trace))?;
-    let rows =
+    let rows = 
         <crate::circuit::SuperCircuit as TargetCircuit>::Inner::min_num_rows_block_subcircuits(
             &witness_block,
         )
@@ -280,6 +282,74 @@ pub fn decode_bytecode(bytecode: &str) -> Result<Vec<u8>, anyhow::Error> {
     hex::decode(stripped).map_err(|e| e.into())
 }
 
+#[derive(Debug, Clone)]
+struct PoseidonCodeHash {
+    bytes_in_field: usize,
+}
+
+impl PoseidonCodeHash {
+    fn new(bytes_in_field: usize) -> Self {
+        Self { bytes_in_field }
+    }
+}
+
+impl CodeHash for PoseidonCodeHash {
+    fn hash_code(&self, code: &[u8]) -> Hash {
+        use mpt_zktrie::hash::MessageHashable;
+        use halo2_proofs::halo2curves::group::ff::PrimeField;
+        let fls = (0..(code.len() / self.bytes_in_field))
+            .map(|i| i * self.bytes_in_field)
+            .map(|i| {
+                let mut buf: [u8; 32] = [0; 32];
+                U256::from_big_endian(&code[i..i + self.bytes_in_field]).to_little_endian(&mut buf);
+                Fr::from_bytes(&buf).unwrap()
+            });
+        let msgs: Vec<_> = fls
+            .chain(if code.len() % self.bytes_in_field == 0 {
+                None
+            } else {
+                let last_code = &code[code.len() - code.len() % self.bytes_in_field..];
+                // pad to bytes_in_field
+                let mut last_buf = vec![0u8; self.bytes_in_field];
+                last_buf.as_mut_slice()[..last_code.len()].copy_from_slice(last_code);
+                let mut buf: [u8; 32] = [0; 32];
+                U256::from_big_endian(&last_buf).to_little_endian(&mut buf);
+                Some(Fr::from_bytes(&buf).unwrap())
+            })
+            .collect();
+
+        let h = Fr::hash_msg(&msgs, Some(code.len() as u64));
+
+        let mut buf: [u8; 32] = [0; 32];
+        U256::from_little_endian(h.to_repr().as_ref()).to_big_endian(&mut buf);
+        Hash::from_slice(&buf)
+    }
+}
+
+#[test]
+fn code_hashing() {
+    let code_hasher = PoseidonCodeHash::new(16);
+    let simple_byte: [u8; 1] = [0];
+    assert_eq!(
+        format!("{:?}", code_hasher.hash_code(&simple_byte)),
+        "0x0ee069e6aa796ef0e46cbd51d10468393d443a00f5affe72898d9ab62e335e16"
+    );
+
+    let simple_byte: [u8; 2] = [0, 1];
+    assert_eq!(
+        format!("{:?}", code_hasher.hash_code(&simple_byte)),
+        "0x26cd650aa0d0b9aada79f5f7c03c5961430c12a2142832789fc31a4188d762ff"
+    );
+
+    let example = "608060405234801561001057600080fd5b506004361061004c5760003560e01c806321848c46146100515780632e64cec11461006d578063b0f2b72a1461008b578063f3417673146100a7575b600080fd5b61006b60048036038101906100669190610116565b6100c5565b005b6100756100da565b604051610082919061014e565b60405180910390f35b6100a560048036038101906100a09190610116565b6100e3565b005b6100af6100ed565b6040516100bc919061014e565b60405180910390f35b8060008190555060006100d757600080fd5b50565b60008054905090565b8060008190555050565b6000806100f957600080fd5b600054905090565b60008135905061011081610173565b92915050565b60006020828403121561012857600080fd5b600061013684828501610101565b91505092915050565b61014881610169565b82525050565b6000602082019050610163600083018461013f565b92915050565b6000819050919050565b61017c81610169565b811461018757600080fd5b5056fea2646970667358221220f4bca934426c76c7cb87cc32876fc6e65d1d7de23424faa61c347ffed95c449064736f6c63430008040033";
+    let bytes = hex::decode(example).unwrap();
+
+    assert_eq!(
+        format!("{:?}", code_hasher.hash_code(&bytes)),
+        "0x0e6d089fa72b508b90e014b486d64a5311df3030c45b10a95366cf53cd1ec9d5"
+    );
+}
+
 /*
 fn get_account_deployed_codehash(
     execution_result: &ExecutionResult,
@@ -316,35 +386,25 @@ fn get_account_created_codehash(step: &ExecStep) -> Result<eth_types::H256, anyh
     }
 }
 */
-fn trace_code(
-    cdb: &mut CodeDB,
-    step: &ExecStep,
-    sdb: &StateDB,
-    code: Bytes,
-    stack_pos: usize,
-) -> Result<(), anyhow::Error> {
+fn trace_code(cdb: &mut CodeDB, step: &ExecStep, sdb: &StateDB, code: Bytes, stack_pos: usize) {
     let stack = step
         .stack
         .as_ref()
         .expect("should have stack in call context");
     let addr = stack[stack.len() - stack_pos - 1].to_address(); //stack N-stack_pos
 
+    let hash = cdb.insert(code.to_vec());
+
+    // sanity check
     let (existed, data) = sdb.get_account(&addr);
-    if !existed {
-        // we may call non-contract or non-exist address
-        if code.as_ref().is_empty() {
-            Ok(())
-        } else {
-            Err(anyhow!("missed account data for {}", addr))
-        }
-    } else {
-        cdb.0.insert(data.code_hash, code.to_vec());
-        Ok(())
-    }
+    if existed && !(data.nonce.is_zero() && data.balance.is_zero()) {
+        assert_eq!(hash, data.code_hash, "invalid codehash for existed account {addr:?}, {data:?}");
+    };
 }
 pub fn build_statedb_and_codedb(blocks: &[BlockTrace]) -> Result<(StateDB, CodeDB), anyhow::Error> {
     let mut sdb = StateDB::new();
-    let mut cdb = CodeDB::new();
+    let mut cdb =
+        CodeDB::new_with_code_hasher(Box::new(PoseidonCodeHash::new(HASHBLOCK_BYTES_IN_FIELD)));
 
     // step1: insert proof into statedb
     for block in blocks.iter().rev() {
@@ -360,8 +420,7 @@ pub fn build_statedb_and_codedb(blocks: &[BlockTrace]) -> Result<(StateDB, CodeD
                     acc_mut.code_hash = acc.data.code_hash;
                     acc_mut.balance = acc.data.balance;
                 } else {
-                    // TODO(@noel2004): please complete the comment below.
-                    // only
+                    // it is essential to set it as default (i.e. not existed account data)
                     sdb.set_account(
                         addr,
                         Account {
@@ -406,13 +465,10 @@ pub fn build_statedb_and_codedb(blocks: &[BlockTrace]) -> Result<(StateDB, CodeD
 
         for execution_result in &block.execution_results {
             if let Some(bytecode) = &execution_result.byte_code {
+                let hash = cdb.insert(decode_bytecode(bytecode)?.to_vec());
+                
                 if execution_result.account_created.is_none() {
-                    cdb.0.insert(
-                        execution_result
-                            .code_hash
-                            .ok_or_else(|| anyhow!("empty code hash in result"))?,
-                        decode_bytecode(bytecode)?.to_vec(),
-                    );
+                    assert_eq!(Some(hash), execution_result.code_hash);
                 }
             }
 
@@ -424,17 +480,15 @@ pub fn build_statedb_and_codedb(blocks: &[BlockTrace]) -> Result<(StateDB, CodeD
                         | OpcodeId::DELEGATECALL
                         | OpcodeId::STATICCALL => {
                             let callee_code = data.get_code_at(1);
-                            trace_code(&mut cdb, step, &sdb, callee_code, 1)?;
+                            trace_code(&mut cdb, step, &sdb, callee_code, 1);
                         }
                         OpcodeId::CREATE | OpcodeId::CREATE2 => {
-                            // TODO: need to insert code to codedb with poseidon codehash
-                            // if the call is persistent
+                            // notice we do not need to insert code for CREATE,
+                            // bustmapping do this job
                         }
                         OpcodeId::EXTCODESIZE | OpcodeId::EXTCODECOPY => {
                             let code = data.get_code_at(0);
-                            trace_code(&mut cdb, step, &sdb, code, 0).unwrap_or_else(|err| {
-                                log::error!("temporarily skip error in EXTCODE op: {}", err);
-                            });
+                            trace_code(&mut cdb, step, &sdb, code, 0);
                         }
 
                         _ => {}


### PR DESCRIPTION
This PR use mpt and hash circuit from zkevm-circuit for stand alone testing.

It also switch the mpt witness generation from block trace into built-in generator completely.

No directly dependent of mpt circuit is required anymore.

The dynamic codehash interface is also induced to proving zkevm-circuit ablility of calculating poseidon codehash
