### PR TITLE
Upgrade mpt circuit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,7 +1959,7 @@ dependencies = [
 [[package]]
 name = "halo2-mpt-circuits"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/mpt-circuit.git?branch=goerli-0215-dual-hash#1857566070dd2c9e8cad06ce9e90d635e1f40023"
+source = "git+https://github.com/scroll-tech/mpt-circuit.git?branch=goerli-0215-dual-hash#ae8acdf37eafbbb5b6dffcb9e977dab465970c83"
 dependencies = [
  "halo2_proofs",
  "hex",


### PR DESCRIPTION
We need to upgrade the implicit depended `halo2-mpt-circuit` with branch `goerli-0215-dual-hash`. The new commit completed some unfinished tunning for dual-codehash so we would not encounter constraint (lookup) failure inside zktrie circuit.