### PR TITLE
[Fix] sanity check for codehash updating

### DIFF
--- a/zkevm/src/circuit/builder.rs
+++ b/zkevm/src/circuit/builder.rs
@@ -385,7 +385,7 @@ fn trace_code(cdb: &mut CodeDB, step: &ExecStep, sdb: &StateDB, code: Bytes, sta
 
     // sanity check
     let (existed, data) = sdb.get_account(&addr);
-    if existed && !(data.nonce.is_zero() && data.balance.is_zero()) {
+    if existed && !data.code_size.is_zero() {
         assert_eq!(
             hash, data.code_hash,
             "invalid codehash for existed account {addr:?}, {data:?}"


### PR DESCRIPTION
There is a sanity check inside `trace_code` which ensure the code hash could not be updated once it has set. The current code is problematic for it check `nonce` or `balance` is non zero (so the account has been 'touched') and purpose code hash would be also updated under this condition. However, user can first transfer value into an account without create any code on it. And the sanity check will complain wrongly under this scene.

This PR change the sanity check to simply consider is there any code has been put into the account (so the `code_size` is not zero).