### PR TITLE
fix: public DEFAULT_SERDE_FORMAT

### DIFF
--- a/zkevm/src/utils.rs
+++ b/zkevm/src/utils.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 use types::eth::{BlockTrace, BlockTraceJsonRpcResult};
 use zkevm_circuits::witness;
 
-pub(crate) const DEFAULT_SERDE_FORMAT: SerdeFormat = SerdeFormat::RawBytesUnchecked;
+pub const DEFAULT_SERDE_FORMAT: SerdeFormat = SerdeFormat::RawBytesUnchecked;
 
 /// return setup params by reading from file or generate new one
 pub fn load_or_create_params(params_dir: &str, degree: usize) -> Result<ParamsKZG<Bn256>> {


### PR DESCRIPTION
Sometimes we should call `load_params()` from outside, so we need to public this `DEFAULT_SERDE_FORMAT`
https://github.com/scroll-tech/scroll/blob/develop/common/libzkp/impl/src/prove.rs#L20-L21
https://github.com/scroll-tech/scroll/blob/develop/common/libzkp/impl/src/verify.rs#L24-L25