### PR TITLE
Replace `env_logger` with `log4rs` for logging to stderr and log file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "ark-std"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,10 +210,10 @@ dependencies = [
  "anyhow",
  "clap",
  "dotenv",
- "env_logger 0.9.3",
  "ethers-providers 1.0.2",
  "itertools",
  "log",
+ "log4rs",
  "rand",
  "rand_xorshift",
  "reqwest",
@@ -871,6 +877,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,9 +1419,9 @@ dependencies = [
 name = "ffi"
 version = "0.3.0"
 dependencies = [
- "env_logger 0.9.3",
  "libc",
  "log",
+ "log4rs",
  "once_cell",
  "rand",
  "serde",
@@ -2326,6 +2343,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "log-mdc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
+
+[[package]]
+name = "log4rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36ca1786d9e79b8193a68d480a0907b612f109537115c6ff655a3a1967533fd"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "chrono",
+ "derivative",
+ "fnv",
+ "libc",
+ "log",
+ "log-mdc",
+ "parking_lot 0.12.1",
+ "thiserror",
+ "thread-id",
+ "winapi",
 ]
 
 [[package]]
@@ -3900,6 +3943,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-id"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee93aa2b8331c0fec9091548843f2c90019571814057da3b783f9de09349d73"
+dependencies = [
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
+
+[[package]]
 name = "time"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4581,7 +4635,6 @@ dependencies = [
  "bus-mapping",
  "chrono",
  "dotenv",
- "env_logger 0.9.3",
  "eth-types",
  "ethers-core 0.17.0",
  "git-version",
@@ -4591,6 +4644,7 @@ dependencies = [
  "is-even",
  "itertools",
  "log",
+ "log4rs",
  "mock",
  "mpt-zktrie",
  "num-bigint",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2021"
 anyhow = "1.0"
 clap = { version = "3.1.3", features = ["derive"] }
 dotenv = "0.15.0"
-env_logger = "0.9.0"
 ethers-providers = "1.0"
 itertools = "0.10.5"
 log = "0.4"
+log4rs = { version = "1.2.0", default_features = false, features = ["console_appender", "file_appender"] }
 rand = "0.8"
 rand_xorshift = "0.3"
 reqwest = { version = "0.11", default-features = false, features = [ "json", "rustls-tls" ] }

--- a/bin/src/mock_testnet.rs
+++ b/bin/src/mock_testnet.rs
@@ -10,14 +10,14 @@ use zkevm::circuit::{
     SUB_CIRCUIT_NAMES,
 };
 use zkevm::prover::Prover;
+use zkevm::utils::init_env_and_log;
 
 const DEFAULT_BEGIN_BATCH: i64 = 1;
 const DEFAULT_END_BATCH: i64 = i64::MAX;
 
 #[tokio::main]
 async fn main() {
-    dotenv::dotenv().ok();
-    env_logger::init();
+    init_env_and_log("mock_testnet");
 
     log::info!("mock-testnet: begin");
 

--- a/bin/src/prove.rs
+++ b/bin/src/prove.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 use zkevm::{
     circuit::{SuperCircuit, AGG_DEGREE},
     prover::Prover,
-    utils::{get_block_trace_from_file, load_or_create_params},
+    utils::{get_block_trace_from_file, init_env_and_log, load_or_create_params},
 };
 
 #[derive(Parser, Debug)]
@@ -32,8 +32,7 @@ struct Args {
 }
 
 fn main() {
-    dotenv::dotenv().ok();
-    env_logger::init();
+    init_env_and_log("prove");
 
     let args = Args::parse();
     let agg_params = load_or_create_params(&args.params_path.unwrap(), *AGG_DEGREE)

--- a/bin/src/setup.rs
+++ b/bin/src/setup.rs
@@ -1,5 +1,8 @@
 use clap::Parser;
-use zkevm::{circuit::DEGREE, utils::load_or_create_params};
+use zkevm::{
+    circuit::DEGREE,
+    utils::{init_env_and_log, load_or_create_params},
+};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -10,8 +13,7 @@ struct Args {
 }
 
 fn main() {
-    dotenv::dotenv().ok();
-    env_logger::init();
+    init_env_and_log("setup");
 
     let args = Args::parse();
     if let Some(path) = args.params_path {

--- a/bin/src/verify.rs
+++ b/bin/src/verify.rs
@@ -6,7 +6,7 @@ use zkevm::prover::{AggCircuitProof, TargetCircuitProof};
 use zkevm::verifier::Verifier;
 use zkevm::{
     circuit::{SuperCircuit, AGG_DEGREE, DEGREE},
-    utils::load_or_create_params,
+    utils::{init_env_and_log, load_or_create_params},
 };
 
 #[derive(Parser, Debug)]
@@ -27,8 +27,7 @@ struct Args {
 }
 
 fn main() {
-    dotenv::dotenv().ok();
-    env_logger::init();
+    init_env_and_log("verify");
 
     let args = Args::parse();
     let params = load_or_create_params(&args.params_path.clone().unwrap(), *DEGREE)

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -13,7 +13,7 @@ types = { path = "../types" }
 
 rand = "0.8"
 log = "0.4"
-env_logger = "0.9.0"
+log4rs = { version = "1.2.0", default_features = false, features = ["console_appender", "file_appender"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0.66"

--- a/ffi/src/prove.rs
+++ b/ffi/src/prove.rs
@@ -3,13 +3,14 @@ use libc::c_char;
 use std::cell::OnceCell;
 use types::eth::BlockTrace;
 use zkevm::prover::Prover;
+use zkevm::utils::init_env_and_log;
 
 static mut PROVER: OnceCell<Prover> = OnceCell::new();
 
 /// # Safety
 #[no_mangle]
 pub unsafe extern "C" fn init_prover(params_path: *const c_char, _seed_path: *const c_char) {
-    env_logger::init();
+    init_env_and_log("ffi_prove");
 
     let params_path = c_char_to_str(params_path);
     let p = Prover::from_param_dir(params_path);

--- a/ffi/src/verify.rs
+++ b/ffi/src/verify.rs
@@ -3,6 +3,7 @@ use libc::c_char;
 use std::fs::File;
 use std::io::Read;
 use zkevm::prover::AggCircuitProof;
+use zkevm::utils::init_env_and_log;
 use zkevm::verifier::Verifier;
 
 static mut VERIFIER: Option<&Verifier> = None;
@@ -10,7 +11,7 @@ static mut VERIFIER: Option<&Verifier> = None;
 /// # Safety
 #[no_mangle]
 pub unsafe extern "C" fn init_verifier(params_path: *const c_char, agg_vk_path: *const c_char) {
-    env_logger::init();
+    init_env_and_log("ffi_verify");
 
     let params_path = c_char_to_str(params_path);
     let agg_vk_path = c_char_to_str(agg_vk_path);

--- a/zkevm/Cargo.toml
+++ b/zkevm/Cargo.toml
@@ -29,11 +29,11 @@ serde_stacker = "0.1"
 serde_json = { version = "1.0.66", features = ["unbounded_depth"] }
 types = { path = "../types", features = ["test"] }
 log = "0.4"
+log4rs = { version = "1.2.0", default_features = false, features = ["console_appender", "file_appender"] }
 anyhow = "1.0"
 num-bigint = "0.4.3"
 blake2 = "0.10.3"
 dotenv = "0.15.0"
-env_logger = "0.9.0"
 strum = "0.24"
 strum_macros = "0.24"
 once_cell = "1.8.0"

--- a/zkevm/src/test_util.rs
+++ b/zkevm/src/test_util.rs
@@ -1,43 +1,11 @@
 use crate::utils::get_block_trace_from_file;
 use crate::utils::read_env_var;
-use chrono::Utc;
-use git_version::git_version;
 use glob::glob;
-use std::fs;
-use std::path::PathBuf;
-use std::str::FromStr;
-use std::sync::Once;
 use types::eth::BlockTrace;
 
 pub mod mock_plonk;
 
-pub const GIT_VERSION: &str = git_version!();
 pub const PARAMS_DIR: &str = "./test_params";
-
-pub static ENV_LOGGER: Once = Once::new();
-
-pub fn init_env_and_log() {
-    ENV_LOGGER.call_once(|| {
-        dotenv::dotenv().ok();
-        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug"))
-            .format_timestamp_millis()
-            .init();
-        log::info!("git version {}", GIT_VERSION);
-    });
-}
-
-pub fn create_output_dir() -> String {
-    let mode = read_env_var("MODE", "multi".to_string());
-    let output = read_env_var(
-        "OUTPUT_DIR",
-        format!("output_{}_{}", Utc::now().format("%Y%m%d_%H%M%S"), mode),
-    );
-
-    let output_dir = PathBuf::from_str(&output).unwrap();
-    fs::create_dir_all(output_dir).unwrap();
-
-    output
-}
 
 pub fn load_batch_traces(batch_dir: &str) -> (Vec<String>, Vec<types::eth::BlockTrace>) {
     let file_names: Vec<String> = glob(&format!("{batch_dir}/**/*.json"))

--- a/zkevm/tests/aggregation_tests.rs
+++ b/zkevm/tests/aggregation_tests.rs
@@ -4,13 +4,12 @@ use snark_verifier_sdk::halo2::aggregation::AggregationCircuit;
 use snark_verifier_sdk::CircuitExt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use test_util::{create_output_dir, init_env_and_log, load_block_traces_for_test};
-use zkevm::circuit::{SuperCircuit, TargetCircuit};
-use zkevm::circuit::{AGG_DEGREE, DEGREE};
+use test_util::load_block_traces_for_test;
+use zkevm::circuit::{SuperCircuit, TargetCircuit, AGG_DEGREE};
 use zkevm::io::write_file;
 use zkevm::prover::{Prover, TargetCircuitProof};
 use zkevm::test_util::{self, PARAMS_DIR};
-use zkevm::utils::load_or_create_params;
+use zkevm::utils::{init_env_and_log, load_or_create_params};
 use zkevm::verifier::EvmVerifier;
 
 // An end to end integration test.
@@ -21,9 +20,8 @@ use zkevm::verifier::EvmVerifier;
 fn test_aggregation_api() {
     std::env::set_var("VERIFY_CONFIG", "./configs/verify_circuit.config");
 
-    init_env_and_log();
+    let output_dir = init_env_and_log("agg_tests");
 
-    let output_dir = create_output_dir();
     let mut output_path = PathBuf::from_str(&output_dir).unwrap();
     log::info!("created output dir {}", output_dir);
 

--- a/zkevm/tests/integration.rs
+++ b/zkevm/tests/integration.rs
@@ -1,17 +1,14 @@
-use std::collections::HashMap;
-
 use chrono::Utc;
-use eth_types::Bytes;
 use halo2_proofs::{plonk::keygen_vk, SerdeFormat};
 use zkevm::{
     capacity_checker::CircuitCapacityChecker,
     circuit::{SuperCircuit, TargetCircuit, DEGREE},
     io::serialize_vk,
     prover::Prover,
-    utils::{get_block_trace_from_file, load_or_create_params, load_params},
+    utils::{get_block_trace_from_file, init_env_and_log, load_or_create_params, load_params},
 };
 
-use test_util::{init_env_and_log, load_block_traces_for_test, PARAMS_DIR};
+use test_util::{load_block_traces_for_test, PARAMS_DIR};
 use zkevm::test_util;
 
 use zkevm_circuits::util::SubCircuit;
@@ -19,7 +16,7 @@ use zkevm_circuits::util::SubCircuit;
 #[ignore]
 #[test]
 fn test_load_params() {
-    init_env_and_log();
+    init_env_and_log("integration");
     log::info!("start");
     load_params(
         "/home/ubuntu/scroll-zkevm/zkevm/test_params",
@@ -43,7 +40,7 @@ fn test_load_params() {
 
 #[test]
 fn test_capacity_checker() {
-    init_env_and_log();
+    init_env_and_log("integration");
 
     let batch = vec![get_block_trace_from_file(
         "./tests/extra_traces/tx_storage_proof.json",
@@ -83,7 +80,7 @@ fn test_capacity_checker() {
 fn estimate_circuit_rows() {
     use zkevm::circuit::{self, TargetCircuit};
 
-    init_env_and_log();
+    init_env_and_log("integration");
 
     let (_, block_trace) = load_block_traces_for_test();
 
@@ -99,7 +96,7 @@ fn test_mock_prove() {
 
     use crate::test_util::load_block_traces_for_test;
 
-    init_env_and_log();
+    init_env_and_log("integration");
     let block_traces = load_block_traces_for_test().1;
     Prover::mock_prove_target_circuit_batch::<circuit::SuperCircuit>(&block_traces).unwrap();
 }
@@ -114,7 +111,7 @@ fn test_prove_verify() {
 #[test]
 fn test_deterministic() {
     use halo2_proofs::dev::MockProver;
-    init_env_and_log();
+    init_env_and_log("integration");
     type C = SuperCircuit;
     let block_trace = load_block_traces_for_test().1;
 
@@ -147,7 +144,7 @@ fn test_deterministic() {
 #[test]
 fn test_vk_same() {
     use halo2_proofs::dev::MockProver;
-    init_env_and_log();
+    init_env_and_log("integration");
     type C = SuperCircuit;
     let block_trace = load_block_traces_for_test().1;
     let params = load_or_create_params(PARAMS_DIR, *DEGREE).unwrap();
@@ -217,7 +214,7 @@ fn test_target_circuit_prove_verify<C: TargetCircuit>() {
 
     use zkevm::verifier::Verifier;
 
-    init_env_and_log();
+    init_env_and_log("integration");
 
     let (_, block_traces) = load_block_traces_for_test();
 

--- a/zkevm/tests/snark_verifier_api.rs
+++ b/zkevm/tests/snark_verifier_api.rs
@@ -8,10 +8,9 @@ use snark_verifier_sdk::halo2::aggregation::AggregationCircuit;
 use snark_verifier_sdk::CircuitExt;
 use snark_verifier_sdk::{gen_pk, halo2::gen_snark_shplonk};
 use test_util::mock_plonk;
-use zkevm::test_util;
-
-use test_util::init_env_and_log;
 use zkevm::prover::Prover;
+use zkevm::test_util;
+use zkevm::utils::init_env_and_log;
 use zkevm::verifier::{EvmVerifier, Verifier};
 
 // This is essentially a same test as snark-verifier/evm-verifier
@@ -26,7 +25,7 @@ fn test_snark_verifier_sdk_api() {
     let k = 8;
     let k_agg = 21;
 
-    init_env_and_log();
+    init_env_and_log("snark_verifier_api");
 
     let mut rng = XorShiftRng::from_seed([0u8; 16]);
 
@@ -87,7 +86,7 @@ fn test_partial_aggregation_api() {
 
     std::env::set_var("VERIFY_CONFIG", "./configs/verify_circuit.config");
 
-    init_env_and_log();
+    init_env_and_log("snark_verifier_api");
     let num_snarks = 3;
 
     // ====================================================


### PR DESCRIPTION
### Summary

After some investigation, `env_logger` seems to be hard to output logs to both stderr and a file, reference [this-comment](https://github.com/rust-cli/env_logger/issues/125#issuecomment-1406333500) (cannot set two `Target`s for a builder).

I fix to replace it with `log4rs`. It could write to both stderr and a file. But it cannot parse complicated `RUST_LOG` (only for simple ones as `RUST_LOG=info`).

The output logs as:
```
2023-06-05T16:36:13.734462+08:00 INFO zkevm::utils - git version prealpha-v2.0-24-gff7853e-modified
2023-06-05T16:36:13.734718+08:00 INFO aggregation_tests - created output dir agg_tests_output_multi_20230605_083613
2023-06-05T16:36:13.734763+08:00 INFO zkevm::test_util - using mode "multiple", testing with "./tests/traces/erc20/erc20_10_transfer.json"
2023-06-05T16:36:13.734810+08:00 INFO zkevm::test_util - test cases traces: ["./tests/traces/erc20/erc20_10_transfer.json"]
2023-06-05T16:36:13.745844+08:00 INFO aggregation_tests - loaded block trace
2023-06-05T16:36:13.752003+08:00 INFO zkevm::utils - load_or_create_params ./test_params/params25
2023-06-05T16:36:13.752046+08:00 INFO zkevm::utils - start loading params with degree 25
2023-06-05T16:36:16.945282+08:00 INFO zkevm::utils - load params successfully!
```